### PR TITLE
Cross-build settings for Scala 2.10/2.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,41 +5,38 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.github.yousef-fadila</groupId>
-    <artifactId>akka-couchbase-persistence</artifactId>
+    <artifactId>akka-couchbase-persistence_${scala.cross.version}</artifactId>
     <version>1.0</version>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <scala.version>2.10.5</scala.version>
+        <scala.cross.version>2.10</scala.cross.version>
         <akka.version>2.3.9</akka.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-persistence-experimental_2.10</artifactId>
+            <artifactId>akka-persistence-experimental_${scala.cross.version}</artifactId>
             <version>${akka.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-slf4j_2.10</artifactId>
+            <artifactId>akka-slf4j_${scala.cross.version}</artifactId>
             <version>${akka.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-contrib_2.10</artifactId>
+            <artifactId>akka-contrib_${scala.cross.version}</artifactId>
             <version>${akka.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-persistence-tck-experimental_2.10</artifactId>
-            <version>${akka.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-persistence-tck-experimental_2.10</artifactId>
+            <artifactId>akka-persistence-tck-experimental_${scala.cross.version}</artifactId>
             <version>${akka.version}</version>
             <scope>test</scope>
         </dependency>
@@ -52,7 +49,7 @@
 
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-testkit_2.10</artifactId>
+            <artifactId>akka-testkit_${scala.cross.version}</artifactId>
             <version>${akka.version}</version>
             <scope>test</scope>
         </dependency>
@@ -64,4 +61,42 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.3</version>
+                    <configuration>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                        <debug>true</debug>
+                        <encoding>UTF-8</encoding>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>eleven</id>
+            <activation>
+                <property>
+                    <name>scala.cross.version</name>
+                    <value>2.11</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.scala-lang.modules</groupId>
+                    <artifactId>scala-xml_${scala.cross.version}</artifactId>
+                    <version>1.0.4</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
I've added some Maven settings to enable alternative compilation for Scala 2.11. If no external properties are defined, the build will target 2.10, as earlier.